### PR TITLE
Fix query encoding for trip search

### DIFF
--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -13,7 +13,13 @@ const Home: NextPage = () => {
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
-    router.push(`/trips?origin=${origin}&destination=${destination}&departureDate=${date}&passengers=${passengers}`);
+    const query = new URLSearchParams({
+      origin: origin.trim(),
+      destination: destination.trim(),
+      departureDate: date,
+      passengers: passengers.toString(),
+    });
+    router.push(`/trips?${query.toString()}`);
   };
 
   return (


### PR DESCRIPTION
## Summary
- encode URI parameters when navigating to trip search

## Testing
- `pnpm lint` *(fails: ESLint config missing)*
- `npx tsc -p apps/web/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_684ca713cfcc83319a99cf60d1feed77