### PR TITLE
Fix missing supabase client imports

### DIFF
--- a/apps/web/src/lib/supabaseClient.ts
+++ b/apps/web/src/lib/supabaseClient.ts
@@ -1,0 +1,10 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('Missing Supabase URL or anonymous key');
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/apps/web/src/pages/login.tsx
+++ b/apps/web/src/pages/login.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import type { NextPage } from 'next';
 import { useRouter } from 'next/router';
-import { supabase } from '../lib/supabaseClient';
+import { useSupabaseClient } from '@supabase/auth-helpers-react';
 
 const Login: NextPage = () => {
   const [email, setEmail] = useState('');
@@ -10,6 +10,7 @@ const Login: NextPage = () => {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const router = useRouter();
+  const supabase = useSupabaseClient();
 
   const handleLogin = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/apps/web/src/pages/profile/edit.tsx
+++ b/apps/web/src/pages/profile/edit.tsx
@@ -2,11 +2,11 @@ import { useEffect, useState } from 'react';
 import type { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
-import { useSession } from '../../lib/SessionContext';
+import { useSession } from '@supabase/auth-helpers-react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 
 const EditProfilePage: NextPage = () => {
-  const { session } = useSession();
+  const session = useSession();
   const router = useRouter();
   const [profile, setProfile] = useState<any>(null);
 

--- a/apps/web/src/pages/profile/edit/[field].tsx
+++ b/apps/web/src/pages/profile/edit/[field].tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState } from 'react';
 import type { NextPage } from 'next';
 import { useRouter } from 'next/router';
-import { useSession } from '../../../lib/SessionContext';
-import { supabase } from '../../../lib/supabaseClient';
+import { useSession, useSupabaseClient } from '@supabase/auth-helpers-react';
 import { ChevronLeft, X } from 'lucide-react';
 
 const fieldLabels: { [key: string]: string } = {
@@ -16,7 +15,8 @@ const fieldLabels: { [key: string]: string } = {
 const EditFieldPage: NextPage = () => {
   const router = useRouter();
   const { field } = router.query;
-  const { session } = useSession();
+  const session = useSession();
+  const supabase = useSupabaseClient();
 
   const [value, setValue] = useState('');
   const [loading, setLoading] = useState(false);

--- a/apps/web/src/pages/signup.tsx
+++ b/apps/web/src/pages/signup.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import type { NextPage } from 'next';
-import { supabase } from '../lib/supabaseClient';
+import { useSupabaseClient } from '@supabase/auth-helpers-react';
 
 const Signup: NextPage = () => {
   const [name, setName] = useState('');
@@ -9,6 +9,7 @@ const Signup: NextPage = () => {
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const supabase = useSupabaseClient();
 
   const handleSignup = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/apps/web/src/pages/trips/index.tsx
+++ b/apps/web/src/pages/trips/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import type { NextPage } from 'next';
 import Link from 'next/link';
-import { supabase } from '../../lib/supabaseClient';
+import { useSupabaseClient } from '@supabase/auth-helpers-react';
 import { Star, Moon } from 'lucide-react';
 import AutocompleteInput from '../../components/AutocompleteInput';
 
@@ -31,6 +31,7 @@ const formatTime = (date: Date) => {
 const TripsListPage: NextPage = () => {
   const [trips, setTrips] = useState<Trip[]>([]);
   const [loading, setLoading] = useState(true);
+  const supabase = useSupabaseClient();
   
   const [origin, setOrigin] = useState('');
   const [destination, setDestination] = useState('');

--- a/apps/web/src/pages/user/[id].tsx
+++ b/apps/web/src/pages/user/[id].tsx
@@ -1,7 +1,7 @@
 import { GetServerSideProps, NextPage } from 'next';
 import { CheckCircle, MessageSquare, Music, PawPrint, Search, Star, Wind } from 'lucide-react';
 import { calculateAge } from '../../utils/helpers';
-import { supabase } from '../../lib/supabaseClient';
+import { createServerSupabaseClient } from '@supabase/auth-helpers-nextjs';
 
 // L'interfaccia `Profile` riflette la tabella `public.profiles`
 // dopo la migrazione `update_profiles_table.sql`.
@@ -98,6 +98,8 @@ const PublicProfilePage: NextPage<PublicProfilePageProps> = ({ profile, error })
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { id } = context.params!;
+
+  const supabase = createServerSupabaseClient(context);
 
   // This call requires a public `profiles` table with RLS enabled.
   const { data: profile, error } = await supabase


### PR DESCRIPTION
## Summary
- restore `supabaseClient.ts`
- update pages to use `useSupabaseClient` and new auth helpers

## Testing
- `pnpm test`
- `pnpm lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_684dac3705f48331a4461cbb153db812